### PR TITLE
Add gogram

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,6 +16,7 @@ on:
           - 05_wtelegramclient
           - 06_madelineproto
           - 07_pyrogrammod
+          - 08_gogram
         required: true
 
 permissions:
@@ -246,6 +247,31 @@ jobs:
           cd 07_pyrogrammod/
           poetry install
           poetry run python main.py
+
+          cd ../
+          ./_commit.sh
+
+  # 08_gogram
+  gogram:
+    if: github.event.inputs.library == '08_gogram' || github.event.inputs.library == 'All'
+    runs-on: ubuntu-latest
+    env:
+      API_ID: ${{ secrets.API_ID }}
+      API_HASH: ${{ secrets.API_HASH }}
+      AUTH_STRING: ${{ secrets.AUTH_STRING_08 }}
+      MESSAGE_LINK: ${{ secrets.MESSAGE_LINK }}
+      CHAT_ID: ${{ secrets.CHAT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache-dependency-path: 08_gogram/go.sum
+
+      - run: |
+          cd 08_gogram/
+          go run .
 
           cd ../
           ./_commit.sh

--- a/08_gogram/go.mod
+++ b/08_gogram/go.mod
@@ -1,0 +1,5 @@
+module github.com/rojvv/tglib-bench/08_gogram
+
+go 1.25.0
+
+require github.com/amarnathcjd/gogram v1.7.6

--- a/08_gogram/go.sum
+++ b/08_gogram/go.sum
@@ -1,0 +1,2 @@
+github.com/amarnathcjd/gogram v1.7.6 h1:t3fK3brMcIA2aNUlNQT1xkrhF9k0eaOgzxYV8xtfU40=
+github.com/amarnathcjd/gogram v1.7.6/go.mod h1:tHC1utX4VHx6jJ9S9JcctCJQflBaZy3i+C26gsqv0ts=

--- a/08_gogram/main.go
+++ b/08_gogram/main.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/amarnathcjd/gogram/telegram"
+)
+
+func main() {
+	cfg, err := loadEnv()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	client, err := telegram.NewClient(telegram.ClientConfig{
+		AppID:         cfg.apiID,
+		AppHash:       cfg.apiHash,
+		StringSession: cfg.authString,
+		MemorySession: true,
+		DisableCache:  true,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "NewClient:", err)
+		os.Exit(1)
+	}
+
+	if err := client.Connect(); err != nil {
+		fmt.Fprintln(os.Stderr, "Connect:", err)
+		os.Exit(1)
+	}
+	defer client.Disconnect()
+
+	peer, msgID, err := parseMessageLink(cfg.messageLink)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "parseMessageLink:", err)
+		os.Exit(1)
+	}
+
+	message, err := client.GetMessageByID(peer, msgID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "GetMessageByID:", err)
+		os.Exit(1)
+	}
+	doc := message.Document()
+	if doc == nil {
+		fmt.Fprintln(os.Stderr, "Message has no document.")
+		os.Exit(1)
+	}
+
+	timestamps := make([]float64, 0, 4)
+
+	timestamps = append(timestamps, now())
+	path, err := message.Download(&telegram.DownloadOptions{
+		FileName: "downloaded.bin",
+	})
+	timestamps = append(timestamps, now())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Download:", err)
+		os.Exit(1)
+	}
+
+	timestamps = append(timestamps, now())
+	if _, err := client.SendMedia(cfg.chatID, path); err != nil {
+		fmt.Fprintln(os.Stderr, "SendMedia:", err)
+		os.Exit(1)
+	}
+	timestamps = append(timestamps, now())
+
+	result := [3]any{doc.Size, timestamps, strings.TrimPrefix(telegram.Version, "v")}
+	out, err := json.Marshal(result)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Marshal:", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile("results.json", out, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "WriteFile:", err)
+		os.Exit(1)
+	}
+}
+
+func now() float64 {
+	return float64(time.Now().UnixMilli()) / 1000.0
+}
+
+type env struct {
+	apiID       int32
+	apiHash     string
+	authString  string
+	messageLink string
+	chatID      int64
+}
+
+func loadEnv() (*env, error) {
+	apiIDStr := os.Getenv("API_ID")
+	if apiIDStr == "" {
+		return nil, errors.New("API_ID not set")
+	}
+	apiID64, err := strconv.ParseInt(apiIDStr, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid API_ID: %w", err)
+	}
+	apiHash := os.Getenv("API_HASH")
+	if apiHash == "" {
+		return nil, errors.New("API_HASH not set")
+	}
+	authString := os.Getenv("AUTH_STRING")
+	if authString == "" {
+		return nil, errors.New("AUTH_STRING not set")
+	}
+	messageLink := os.Getenv("MESSAGE_LINK")
+	if messageLink == "" {
+		return nil, errors.New("MESSAGE_LINK not set")
+	}
+	chatIDStr := os.Getenv("CHAT_ID")
+	if chatIDStr == "" {
+		return nil, errors.New("CHAT_ID not set")
+	}
+	chatID, err := strconv.ParseInt(chatIDStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CHAT_ID: %w", err)
+	}
+	return &env{
+		apiID:       int32(apiID64),
+		apiHash:     apiHash,
+		authString:  authString,
+		messageLink: messageLink,
+		chatID:      chatID,
+	}, nil
+}
+
+// parseMessageLink returns the peer (channel ID for /c/ links, username otherwise)
+// and the message ID from a t.me URL.
+func parseMessageLink(link string) (any, int32, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, 0, err
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 {
+		return nil, 0, fmt.Errorf("unexpected message link: %q", link)
+	}
+	msgPart := parts[len(parts)-1]
+	chatPart := parts[len(parts)-2]
+	msgID64, err := strconv.ParseInt(msgPart, 10, 32)
+	if err != nil {
+		return nil, 0, fmt.Errorf("invalid message id %q: %w", msgPart, err)
+	}
+	if parts[0] == "c" {
+		channelID, err := strconv.ParseInt(chatPart, 10, 64)
+		if err != nil {
+			return nil, 0, fmt.Errorf("invalid channel id %q: %w", chatPart, err)
+		}
+		return -1_000_000_000_000 - channelID, int32(msgID64), nil
+	}
+	return chatPart, int32(msgID64), nil
+}


### PR DESCRIPTION
Adds a benchmark for [gogram](https://github.com/amarnathcjd/gogram), a Go MTProto client library.

## Summary
- New `08_gogram/` directory with `main.go`, `go.mod`, `go.sum`
- Mirrors the existing contract: reads `API_ID`, `API_HASH`, `AUTH_STRING`, `MESSAGE_LINK`, `CHAT_ID`; downloads the linked document, re-uploads to `CHAT_ID`, writes `results.json` as `[file_size, [d_start, d_end, u_start, u_end], version]`
- New `gogram` job in `.github/workflows/bench.yml` (uses `actions/setup-go@v5` with Go 1.25, since gogram requires `go 1.25`); secret name follows the pattern: `AUTH_STRING_08`

## Notes
- Session is loaded from `AUTH_STRING` (gogram's `StringSession`) with `MemorySession: true` and `DisableCache: true` so the runner is stateless — no session file or cache to persist between runs.
- `MESSAGE_LINK` is parsed locally to handle both `t.me/<username>/<id>` and `t.me/c/<channel_id>/<id>`.
- `telegram.Version` is recorded in the results JSON for parity with the WTelegramClient/pyrogrammod entries.
- No baseline `results.json` is included (matches the `06_madelineproto` convention) — the first CI run will populate it.

I'm happy to adjust the secret name, job placement, or any conventions you'd prefer.