### PR TITLE
08_gogram: in-memory download, upload-only

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -260,7 +260,6 @@ jobs:
       API_HASH: ${{ secrets.API_HASH }}
       AUTH_STRING: ${{ secrets.AUTH_STRING_08 }}
       MESSAGE_LINK: ${{ secrets.MESSAGE_LINK }}
-      CHAT_ID: ${{ secrets.CHAT_ID }}
     steps:
       - uses: actions/checkout@v4
 

--- a/08_gogram/main.go
+++ b/08_gogram/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -56,20 +57,18 @@ func main() {
 	}
 
 	timestamps := make([]float64, 0, 4)
+	buf := bytes.NewBuffer(make([]byte, 0, doc.Size))
 
 	timestamps = append(timestamps, now())
-	path, err := message.Download(&telegram.DownloadOptions{
-		FileName: "downloaded.bin",
-	})
-	timestamps = append(timestamps, now())
-	if err != nil {
+	if _, err := message.Download(&telegram.DownloadOptions{Buffer: buf}); err != nil {
 		fmt.Fprintln(os.Stderr, "Download:", err)
 		os.Exit(1)
 	}
+	timestamps = append(timestamps, now())
 
 	timestamps = append(timestamps, now())
-	if _, err := client.SendMedia(cfg.chatID, path); err != nil {
-		fmt.Fprintln(os.Stderr, "SendMedia:", err)
+	if _, err := client.UploadFile(buf.Bytes(), &telegram.UploadOptions{FileName: "gogram.bin"}); err != nil {
+		fmt.Fprintln(os.Stderr, "UploadFile:", err)
 		os.Exit(1)
 	}
 	timestamps = append(timestamps, now())
@@ -95,7 +94,6 @@ type env struct {
 	apiHash     string
 	authString  string
 	messageLink string
-	chatID      int64
 }
 
 func loadEnv() (*env, error) {
@@ -119,20 +117,11 @@ func loadEnv() (*env, error) {
 	if messageLink == "" {
 		return nil, errors.New("MESSAGE_LINK not set")
 	}
-	chatIDStr := os.Getenv("CHAT_ID")
-	if chatIDStr == "" {
-		return nil, errors.New("CHAT_ID not set")
-	}
-	chatID, err := strconv.ParseInt(chatIDStr, 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("invalid CHAT_ID: %w", err)
-	}
 	return &env{
 		apiID:       int32(apiID64),
 		apiHash:     apiHash,
 		authString:  authString,
 		messageLink: messageLink,
-		chatID:      chatID,
 	}, nil
 }
 


### PR DESCRIPTION
Follow-up to #5. Aligns the gogram benchmark with the way other libraries (e.g. WTelegramClient) account for the upload phase: no disk hops, and the upload timing covers only the upload itself.

## Changes
- Download streams into `bytes.Buffer` via `DownloadOptions.Buffer` instead of writing to a temp file.
- Upload uses `client.UploadFile(buf.Bytes(), …)` — pure upload, no `SendMedia` / no fire-and-forget send to the chat.
- `CHAT_ID` requirement dropped from both `08_gogram/main.go` and the `gogram` job's env (no longer needed).

`results.json` format unchanged: `[file_size, [d_start, d_end, u_start, u_end], version]`.