### PR TITLE
Fix gogram

### DIFF
--- a/08_gogram/main.go
+++ b/08_gogram/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -56,23 +57,42 @@ func main() {
 	}
 
 	timestamps := make([]float64, 0, 4)
+	buf := bytes.NewBuffer(make([]byte, 0, doc.Size))
 
 	timestamps = append(timestamps, now())
-	path, err := message.Download(&telegram.DownloadOptions{
-		FileName: "downloaded.bin",
-	})
-	timestamps = append(timestamps, now())
-	if err != nil {
+	if _, err := message.Download(&telegram.DownloadOptions{Buffer: buf}); err != nil {
 		fmt.Fprintln(os.Stderr, "Download:", err)
 		os.Exit(1)
 	}
+	timestamps = append(timestamps, now())
 
 	timestamps = append(timestamps, now())
-	if _, err := client.SendMedia(cfg.chatID, path); err != nil {
-		fmt.Fprintln(os.Stderr, "SendMedia:", err)
+	uploaded, err := client.UploadFile(buf.Bytes(), &telegram.UploadOptions{FileName: "gogram.bin"})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "UploadFile:", err)
 		os.Exit(1)
 	}
 	timestamps = append(timestamps, now())
+
+	target, err := client.ResolvePeer(cfg.chatID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "ResolvePeer:", err)
+		os.Exit(1)
+	}
+	if _, err := client.MessagesSendMedia(&telegram.MessagesSendMediaParams{
+		Peer: target,
+		Media: &telegram.InputMediaUploadedDocument{
+			File:     uploaded,
+			MimeType: "application/octet-stream",
+			Attributes: []telegram.DocumentAttribute{
+				&telegram.DocumentAttributeFilename{FileName: "gogram.bin"},
+			},
+		},
+		RandomID: telegram.GenerateRandomLong(),
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "MessagesSendMedia:", err)
+		os.Exit(1)
+	}
 
 	result := [3]any{doc.Size, timestamps, strings.TrimPrefix(telegram.Version, "v")}
 	out, err := json.Marshal(result)


### PR DESCRIPTION
Follow-up to #5; supersedes #6.

## Changes
- Download streams into a `bytes.Buffer` via `DownloadOptions.Buffer` — no disk hops.
- Upload is timed in isolation via `client.UploadFile(buf.Bytes(), …)`, which returns an `InputFile`.
- After the upload timestamp is recorded, the file is actually sent to `CHAT_ID` as a document by constructing `InputMediaUploadedDocument` and calling `client.MessagesSendMedia(...)` directly (with a `DocumentAttributeFilename` attribute). This mirrors how WTelegramClient measures the upload separately and then dispatches the send.

`results.json` format unchanged: `[file_size, [d_start, d_end, u_start, u_end], version]`. `CHAT_ID` is required again (used as the send target).