### PR TITLE
Add mtgo

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,6 +17,7 @@ on:
           - 06_madelineproto
           - 07_pyrogrammod
           - 08_gogram
+          - 09_mtgo
         required: true
 
 permissions:
@@ -271,6 +272,31 @@ jobs:
 
       - run: |
           cd 08_gogram/
+          go run .
+
+          cd ../
+          ./_commit.sh
+
+  # 09_mtgo
+  mtgo:
+    if: github.event.inputs.library == '09_mtgo' || github.event.inputs.library == 'All'
+    runs-on: ubuntu-latest
+    env:
+      API_ID: ${{ secrets.API_ID }}
+      API_HASH: ${{ secrets.API_HASH }}
+      AUTH_STRING: ${{ secrets.AUTH_STRING_09 }}
+      MESSAGE_LINK: ${{ secrets.MESSAGE_LINK }}
+      CHAT_ID: ${{ secrets.CHAT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache-dependency-path: 09_mtgo/go.sum
+
+      - run: |
+          cd 09_mtgo/
           go run .
 
           cd ../

--- a/09_mtgo/go.mod
+++ b/09_mtgo/go.mod
@@ -1,0 +1,14 @@
+module github.com/rojvv/tglib-bench/09_mtgo
+
+go 1.26.2
+
+require github.com/mtgo-labs/mtgo v0.10.1
+
+require (
+	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/mtgo-labs/storage v0.4.0 // indirect
+	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/term v0.44.0 // indirect
+)

--- a/09_mtgo/go.sum
+++ b/09_mtgo/go.sum
@@ -1,0 +1,16 @@
+github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
+github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/mtgo-labs/mtgo v0.10.1 h1:x3X0sZLwU7fVfThxCAw/u7ZHn1US13oOI5Q46grcBI0=
+github.com/mtgo-labs/mtgo v0.10.1/go.mod h1:S7NWS71niPpXfDJiH9HsPM5ST3wcKusdeJCv6tveVR8=
+github.com/mtgo-labs/storage v0.4.0 h1:vfZGeLSrPux45y6S3PTtpQ302fEZxlItuzC2HRfTKl8=
+github.com/mtgo-labs/storage v0.4.0/go.mod h1:sBMyZUmM0laJr1Zx4bAyYeQ6jpMCZJ64WPHcL8kNj70=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
+golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=

--- a/09_mtgo/main.go
+++ b/09_mtgo/main.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mtgo-labs/mtgo/telegram"
+	"github.com/mtgo-labs/mtgo/telegram/types"
+	"github.com/mtgo-labs/mtgo/tg"
+)
+
+func main() {
+	cfg, err := loadEnv()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	client, err := telegram.NewClient(cfg.apiID, cfg.apiHash, &telegram.Config{
+		SessionString: cfg.authString,
+		InMemory:      true,
+		SavePeers:     true,
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "NewClient:", err)
+		os.Exit(1)
+	}
+
+	if err := client.Connect(0); err != nil {
+		fmt.Fprintln(os.Stderr, "Connect:", err)
+		os.Exit(1)
+	}
+	defer client.Stop()
+
+	chatID, msgID, err := resolveMessageLink(ctx, client, cfg.messageLink)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "resolve link:", err)
+		os.Exit(1)
+	}
+
+	msgs, err := client.GetMessages(ctx, chatID, []int32{msgID})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "GetMessages:", err)
+		os.Exit(1)
+	}
+	if len(msgs) == 0 || msgs[0].Media == nil {
+		fmt.Fprintln(os.Stderr, "message has no media")
+		os.Exit(1)
+	}
+
+	doc, ok := msgs[0].Media.(*types.DocumentMedia)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "message media is not a document")
+		os.Exit(1)
+	}
+
+	var ts [4]float64
+
+	ts[0] = now()
+	data, err := client.DownloadMedia(ctx, msgs[0].Media, "", nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "DownloadMedia:", err)
+		os.Exit(1)
+	}
+	ts[1] = now()
+
+	ts[2] = now()
+	result, err := client.UploadFile(ctx, bytes.NewReader(data), "mtgo.bin", int64(len(data)), nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "UploadFile:", err)
+		os.Exit(1)
+	}
+	ts[3] = now()
+
+	media := &tg.InputMediaUploadedDocument{
+		File:       result.File,
+		MimeType:   doc.MimeType,
+		Attributes: []tg.DocumentAttributeClass{&tg.DocumentAttributeFilename{FileName: "mtgo.bin"}},
+	}
+	if _, err := client.SendMedia(ctx, cfg.chatID, media, ""); err != nil {
+		fmt.Fprintln(os.Stderr, "SendMedia:", err)
+		os.Exit(1)
+	}
+
+	out, err := json.Marshal([3]any{doc.FileSize, ts[:], mtgoVersion()})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "json marshal:", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile("results.json", out, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "write results:", err)
+		os.Exit(1)
+	}
+}
+
+func now() float64 {
+	return float64(time.Now().UnixMilli()) / 1000.0
+}
+
+func mtgoVersion() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, dep := range bi.Deps {
+		if dep.Path == "github.com/mtgo-labs/mtgo" {
+			return strings.TrimPrefix(dep.Version, "v")
+		}
+	}
+	return "unknown"
+}
+
+type env struct {
+	apiID       int32
+	apiHash     string
+	authString  string
+	messageLink string
+	chatID      int64
+}
+
+func loadEnv() (*env, error) {
+	apiIDStr := os.Getenv("API_ID")
+	if apiIDStr == "" {
+		return nil, errors.New("API_ID not set")
+	}
+	apiID64, err := strconv.ParseInt(apiIDStr, 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid API_ID: %w", err)
+	}
+	apiHash := os.Getenv("API_HASH")
+	if apiHash == "" {
+		return nil, errors.New("API_HASH not set")
+	}
+	authString := os.Getenv("AUTH_STRING")
+	if authString == "" {
+		return nil, errors.New("AUTH_STRING not set")
+	}
+	messageLink := os.Getenv("MESSAGE_LINK")
+	if messageLink == "" {
+		return nil, errors.New("MESSAGE_LINK not set")
+	}
+	chatIDStr := os.Getenv("CHAT_ID")
+	if chatIDStr == "" {
+		return nil, errors.New("CHAT_ID not set")
+	}
+	chatID, err := strconv.ParseInt(chatIDStr, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CHAT_ID: %w", err)
+	}
+	return &env{
+		apiID:       int32(apiID64),
+		apiHash:     apiHash,
+		authString:  authString,
+		messageLink: messageLink,
+		chatID:      chatID,
+	}, nil
+}
+
+// resolveMessageLink parses a t.me message link and returns the chat ID and
+// message ID. For /c/ links the channel ID is converted to the negative bot-API
+// format; for username links the username is resolved to obtain the channel ID.
+func resolveMessageLink(ctx context.Context, client *telegram.Client, link string) (int64, int32, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return 0, 0, err
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("unexpected message link: %q", link)
+	}
+	msgPart := parts[len(parts)-1]
+	chatPart := parts[len(parts)-2]
+	msgID64, err := strconv.ParseInt(msgPart, 10, 32)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid message id %q: %w", msgPart, err)
+	}
+	if parts[0] == "c" {
+		channelID, err := strconv.ParseInt(chatPart, 10, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid channel id %q: %w", chatPart, err)
+		}
+		return -1_000_000_000_000 - channelID, int32(msgID64), nil
+	}
+	peer, err := client.ResolvePeer(ctx, chatPart)
+	if err != nil {
+		return 0, 0, fmt.Errorf("resolve username %q: %w", chatPart, err)
+	}
+	if ch, ok := peer.(*tg.InputPeerChannel); ok {
+		return -1_000_000_000_000 - ch.ChannelID, int32(msgID64), nil
+	}
+	return 0, 0, fmt.Errorf("resolved peer %T is not a channel", peer)
+}


### PR DESCRIPTION
## Summary

Adds [mtgo](https://github.com/mtgo-labs/mtgo) as the 9th benchmark library (`09_mtgo`).

## Protocol

Follows the same download → upload → send pattern as gogram:
1. Connect via session string (`AUTH_STRING_09`)
2. Resolve message link → fetch document
3. Download media to memory (timed)
4. Upload to Telegram (timed)
5. Send as document (untimed)
6. Write `results.json`: `[fileSize, [t1, t2, t3, t4], version]`

## CI

- Added `09_mtgo` to the workflow choice dropdown
- Added `mtgo` job using `setup-go@v5` with `go-version: "1.26"`
- Requires `AUTH_STRING_09` secret

## Verification

- `GOWORK=off go build .` ✅
- `GOWORK=off go vet .` ✅
- Protocol verified against all 8 existing implementations