### PR TITLE
Fix mtgo

### DIFF
--- a/09_mtgo/main.go
+++ b/09_mtgo/main.go
@@ -25,12 +25,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
 	client, err := telegram.NewClient(cfg.apiID, cfg.apiHash, &telegram.Config{
 		SessionString: cfg.authString,
 		InMemory:      true,
 		SavePeers:     true,
+		Retries:       5,
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "NewClient:", err)


### PR DESCRIPTION
## Summary
- add a 30-minute context around the mtgo benchmark run
- configure mtgo RPC retries for more robust transfer handling

## Context
The mtgo benchmark can hit the default 60s timeout during cross-DC media downloads, causing `DownloadMedia` to fail before the benchmark can write results.

## Testing
- not run locally end-to-end; requires Telegram benchmark secrets and a source media message