### PR TITLE
Fix mtgo

### DIFF
--- a/09_mtgo/go.mod
+++ b/09_mtgo/go.mod
@@ -2,7 +2,7 @@ module github.com/rojvv/tglib-bench/09_mtgo
 
 go 1.26.2
 
-require github.com/mtgo-labs/mtgo v0.10.1
+require github.com/mtgo-labs/mtgo v0.10.2
 
 require (
 	github.com/klauspost/compress v1.18.6 // indirect

--- a/09_mtgo/go.sum
+++ b/09_mtgo/go.sum
@@ -1,7 +1,7 @@
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
-github.com/mtgo-labs/mtgo v0.10.1 h1:x3X0sZLwU7fVfThxCAw/u7ZHn1US13oOI5Q46grcBI0=
-github.com/mtgo-labs/mtgo v0.10.1/go.mod h1:S7NWS71niPpXfDJiH9HsPM5ST3wcKusdeJCv6tveVR8=
+github.com/mtgo-labs/mtgo v0.10.2 h1:DR3InKR4g5ttSNMh+bgoRxtvBbGfnakd3JNzSfWXaIY=
+github.com/mtgo-labs/mtgo v0.10.2/go.mod h1:S7NWS71niPpXfDJiH9HsPM5ST3wcKusdeJCv6tveVR8=
 github.com/mtgo-labs/storage v0.4.0 h1:vfZGeLSrPux45y6S3PTtpQ302fEZxlItuzC2HRfTKl8=
 github.com/mtgo-labs/storage v0.4.0/go.mod h1:sBMyZUmM0laJr1Zx4bAyYeQ6jpMCZJ64WPHcL8kNj70=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/09_mtgo/main.go
+++ b/09_mtgo/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mtgo-labs/mtgo/telegram"
+	"github.com/mtgo-labs/mtgo/telegram/params"
 	"github.com/mtgo-labs/mtgo/telegram/types"
 	"github.com/mtgo-labs/mtgo/tg"
 )
@@ -27,12 +27,14 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
-
 	client, err := telegram.NewClient(cfg.apiID, cfg.apiHash, &telegram.Config{
 		SessionString: cfg.authString,
 		InMemory:      true,
 		SavePeers:     true,
+		AutoConnect:   true,
+		NoUpdates:     true,
 		Retries:       5,
+		Log:           telegram.LogConfig{Level: telegram.NoLevel},
 	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "NewClient:", err)
@@ -48,6 +50,12 @@ func main() {
 	chatID, msgID, err := resolveMessageLink(ctx, client, cfg.messageLink)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "resolve link:", err)
+		os.Exit(1)
+	}
+
+	_, err = client.ResolvePeer(ctx, cfg.chatID)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Resolve target chat:", err)
 		os.Exit(1)
 	}
 
@@ -70,7 +78,24 @@ func main() {
 	var ts [4]float64
 
 	ts[0] = now()
-	data, err := client.DownloadMedia(ctx, msgs[0].Media, "", nil)
+	tmp, err := os.CreateTemp("", "mtgo-bench-*")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "CreateTemp:", err)
+		os.Exit(1)
+	}
+	tmpPath := tmp.Name()
+	_ = tmp.Close()
+	defer os.Remove(tmpPath)
+
+	err = client.DownloadMediaToFile(ctx, msgs[0].Media, "", tmpPath, doc.FileSize, &params.Download{
+		ChunkSize: 512 * 1024,
+		Workers:   6,
+		Progress: func(info params.ProgressInfo) {
+			if info.DownloadedBytes%(50*1024*1024) < int64(512*1024) {
+				fmt.Printf("[PROGRESS-DL] %d / %d bytes (%.1f%%)\n", info.DownloadedBytes, info.TotalBytes, info.Progress())
+			}
+		},
+	})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "DownloadMedia:", err)
 		os.Exit(1)
@@ -78,7 +103,24 @@ func main() {
 	ts[1] = now()
 
 	ts[2] = now()
-	result, err := client.UploadFile(ctx, bytes.NewReader(data), "mtgo.bin", int64(len(data)), nil)
+	f, err := os.Open(tmpPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Open downloaded file:", err)
+		os.Exit(1)
+	}
+
+	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer uploadCancel()
+	result, err := client.UploadFile(uploadCtx, f, "mtgo.bin", doc.FileSize, &telegram.UploadOptions{
+		Workers: 8,
+		Progress: func(info params.ProgressInfo) {
+			if info.UploadedBytes%(50*1024*1024) < int64(512*1024) {
+				fmt.Printf("[PROGRESS-UL] %d / %d bytes (%.1f%%)\n", info.UploadedBytes, info.TotalBytes, info.Progress())
+			}
+		},
+	})
+	f.Close()
+	os.Remove(tmpPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "UploadFile:", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary

Rewrite the mtgo benchmark to use file-based download/upload instead of loading the entire file into memory, and bump mtgo to v0.10.2.

## Changes

- **Download**: `DownloadMedia` (in-memory `[]byte`) → `DownloadMediaToFile` with 512 KiB chunk size, 6 workers, and progress reporting
- **Upload**: `bytes.NewReader` → file-based `UploadFile` with 30-min context timeout, 8 workers, and progress reporting
- **Peer resolution**: added `ResolvePeer` for the target chat before `GetMessages`
- **Client config**: `AutoConnect`, `NoUpdates`, and `Log: NoLevel`
- **mtgo**: v0.10.1 → v0.10.2