### PR TITLE
Add kurigram benchmark

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -20,6 +20,7 @@ on:
           - 09_mtgo
           - 10_gotd
           - 11_teleproto
+          - 12_kurigram
         required: true
 
 permissions:
@@ -324,6 +325,34 @@ jobs:
       - run: |
           cd 10_gotd/
           go run .
+
+          cd ../
+          ./_commit.sh
+
+  # 12_kurigram
+  kurigram:
+    if: github.event.inputs.library == '12_kurigram' || github.event.inputs.library == 'All'
+    runs-on: ubuntu-latest
+    env:
+      API_ID: ${{ secrets.API_ID }}
+      API_HASH: ${{ secrets.API_HASH }}
+      BOT_TOKEN: ${{ secrets.BOT_TOKEN_12 }}
+      AUTH_STRING: ${{ secrets.AUTH_STRING_12 }}
+      MESSAGE_LINK: ${{ secrets.MESSAGE_LINK }}
+      CHAT_ID: ${{ secrets.CHAT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - run: python -m pip install poetry
+
+      - run: |
+          cd 12_kurigram/
+          poetry install
+          poetry run python main.py
 
           cd ../
           ./_commit.sh

--- a/12_kurigram/env.py
+++ b/12_kurigram/env.py
@@ -1,0 +1,1 @@
+../03_telethon/env.py

--- a/12_kurigram/main.py
+++ b/12_kurigram/main.py
@@ -1,0 +1,62 @@
+import json
+import sys
+import time
+
+from pyrogram import Client
+from pyrogram import __version__
+
+import env
+from util import parse_message_link
+
+app = Client(
+    ":memory:",
+    session_string=env.AUTH_STRING if env.AUTH_STRING else None,
+    api_id=env.API_ID,
+    api_hash=env.API_HASH,
+    no_updates=True,
+)
+app.connect()
+
+if env.EXPORT_AUTH_STRING:
+    app.sign_in_bot(bot_token=env.BOT_TOKEN)
+    print(app.export_session_string())
+    exit(0)
+
+async def main():
+    chat_id, message_id = parse_message_link(env.MESSAGE_LINK)
+
+    timestamps: list[float] = []
+    message = await app.get_messages(chat_id=chat_id, message_ids=message_id)
+    if not message:
+        print("Message not found.", file=sys.stderr)
+        await app.disconnect()
+        sys.exit(1)
+
+    if not message.document:
+        print("Invalid message.", file=sys.stderr)
+        await app.disconnect()
+        sys.exit(1)
+
+    file_size = message.document.file_size
+
+    timestamps.append(time.time())
+    file_name = await message.download()
+    print(f"Downloaded {file_name}", file=sys.stderr)
+    timestamps.append(time.time())
+
+    timestamps.append(time.time())
+    await app.send_document(
+        chat_id=env.CHAT_ID,
+        document=file_name,
+        force_document=True,
+    )
+    timestamps.append(time.time())
+
+    with open("results.json", "w+") as f:
+        json.dump([file_size, timestamps, __version__], f)
+
+    await app.disconnect()
+
+
+if __name__ == "__main__":
+    app.run(main())

--- a/12_kurigram/pyproject.toml
+++ b/12_kurigram/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "12-kurigram"
+version = "0.1.0"
+description = ""
+requires-python = ">=3.11,<4.0"
+dependencies = [
+    "kurigram>=2.2.23",
+    "tgcrypto>=1.2.5",
+]
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+package-mode = false
+
+[tool.poetry.group.dev.dependencies]
+mypy = "^1.15.0"

--- a/12_kurigram/util.py
+++ b/12_kurigram/util.py
@@ -1,0 +1,1 @@
+../03_telethon/util.py


### PR DESCRIPTION
This pull request adds a new benchmark suite for the `12_kurigram` library, integrating it into the CI workflow and providing the necessary project files and scripts. The main changes include workflow updates, new project configuration, and the implementation of the benchmarking script.

**CI/CD Integration:**

* [`.github/workflows/bench.yml`](diffhunk://#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7R23): Added `12_kurigram` as a selectable library in the workflow trigger and defined a new job to run its benchmark, including environment setup and execution steps. [[1]](diffhunk://#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7R23) [[2]](diffhunk://#diff-a5e740be96415373789689f814583e93ff2a8f05eae6481e94505fd6cb6bc6a7R332-R359)

**New Benchmark Suite:**

* [`12_kurigram/main.py`](diffhunk://#diff-bf8fd2f6579f43f46e7e816ada0003763e7ff544f15a5bfff94a3423fd12a0a9R1-R62): Implements the benchmark logic using `pyrogram`, including downloading a document, measuring performance, and exporting results to `results.json`.
* [`12_kurigram/pyproject.toml`](diffhunk://#diff-9bd2cc1c85dc035187f1e62be40e53a870ef6ccff4b89a81383f356df820bfa5R1-R19): Adds project metadata and dependencies for the new suite, including `kurigram` and `tgcrypto`.

**Code Reuse:**

* `12_kurigram/env.py`, `12_kurigram/util.py`: Reuse environment and utility files from `03_telethon` to maintain consistency and reduce duplication. [[1]](diffhunk://#diff-7d27e1a4b30f48e608638324ffdfbb1c76f8f4334594a5e06872505aac43bfb2R1) [[2]](diffhunk://#diff-731adebc740f647c47d253fa2b17181b15c6570b6ce4877538b23157cba7cf94R1)