### PR TITLE
Update teleproto

### DIFF
--- a/12_teleproto/package.json
+++ b/12_teleproto/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "dependencies": {
     "envalid": "^8.0.0",
-    "teleproto": "^1.227.3"
+    "teleproto": "^1.228.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.7"

--- a/12_teleproto/pnpm-lock.yaml
+++ b/12_teleproto/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^8.0.0
         version: 8.2.0
       teleproto:
-        specifier: ^1.227.3
-        version: 1.227.3
+        specifier: ^1.228.0
+        version: 1.228.0
     devDependencies:
       '@types/node':
         specifier: ^24.0.7
@@ -23,9 +23,6 @@ packages:
 
   '@types/node@24.13.2':
     resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
-
-  async-mutex@0.3.2:
-    resolution: {integrity: sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==}
 
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
@@ -69,12 +66,8 @@ packages:
   store2@2.14.4:
     resolution: {integrity: sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==}
 
-  teleproto@1.227.3:
-    resolution: {integrity: sha512-y/azHNmiX01MzqMC7sJrEqEnBHexaUqXie/aITfLUeugiADwkVSzsDs21C2UR4T7AFss6BUw01euByy04gLi8Q==}
-
-  ts-custom-error@3.3.1:
-    resolution: {integrity: sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==}
-    engines: {node: '>=14.0.0'}
+  teleproto@1.228.0:
+    resolution: {integrity: sha512-nHpoWLuzbGWiv3HReOfVA0Qxv9kq+Vp6ENsyBeqDRLcOy+4nHet3I36d+slkhmAAXURDZbHX+Ud8OaQZgcyPsQ==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -90,10 +83,6 @@ snapshots:
   '@types/node@24.13.2':
     dependencies:
       undici-types: 7.18.2
-
-  async-mutex@0.3.2:
-    dependencies:
-      tslib: 2.8.1
 
   big-integer@1.6.52: {}
 
@@ -124,17 +113,13 @@ snapshots:
 
   store2@2.14.4: {}
 
-  teleproto@1.227.3:
+  teleproto@1.228.0:
     dependencies:
-      async-mutex: 0.3.2
       big-integer: 1.6.52
       mime: 3.0.0
       node-localstorage: 2.2.1
       socks: 2.8.9
       store2: 2.14.4
-      ts-custom-error: 3.3.1
-
-  ts-custom-error@3.3.1: {}
 
   tslib@2.8.1: {}
 


### PR DESCRIPTION
Updates teleproto 1.227.3 -> 1.228.0.

Tested in my fork: upload went from 3.3 MiB/s to 13.5 MiB/s, download from 11.2 MiB/s to 14.7 MiB/s (same 2000 MiB file).