### PR TITLE
Update mtflute

### DIFF
--- a/13_mtflute/main.dart
+++ b/13_mtflute/main.dart
@@ -3,7 +3,8 @@ import 'dart:io';
 
 import 'package:mtflute/mtflute.dart';
 
-const String _libVersion = '0.2.6';
+const String _libVersion = '0.2.8';
+const int _threads = 4;
 
 Future<void> main(List<String> args) async {
   final cfg = _loadEnv();
@@ -54,7 +55,8 @@ Future<void> main(List<String> args) async {
       loc,
       dcId: doc.dcId,
       size: doc.size,
-      chunkSize: 512 * 1024,
+      chunkSize: 1024 * 1024,
+      threads: _threads,
     )) {
       sink.add(chunk);
     }
@@ -65,7 +67,11 @@ Future<void> main(List<String> args) async {
   timestamps.add(_now());
 
   timestamps.add(_now());
-  final uploaded = await client.uploadFile(tmp, fileName: 'mtflute.bin');
+  final uploaded = await client.uploadFile(
+    tmp,
+    fileName: 'mtflute.bin',
+    threads: _threads,
+  );
   timestamps.add(_now());
 
   final target = await _resolveChatIdPeer(client, cfg.chatId);

--- a/13_mtflute/pubspec.lock
+++ b/13_mtflute/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: mtflute
-      sha256: dc57c765fd3843add5e4a218cce58fa44b20e26d9218be83efbdd3c048db0cf0
+      sha256: b54bac5e2d1bb6b7aa2d6d7447e1a2a45ab564449c491ad1b101a55fb0057b35
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6"
+    version: "0.2.8"
   pointycastle:
     dependency: transitive
     description:

--- a/13_mtflute/pubspec.yaml
+++ b/13_mtflute/pubspec.yaml
@@ -7,4 +7,4 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  mtflute: ^0.2.6
+  mtflute: ^0.2.8


### PR DESCRIPTION
Bumps `13_mtflute` to `mtflute ^0.2.8` and switches the bench to run
`downloadStream` and `uploadFile` with `threads: 4`, matching the
common configuration used by the other entries.

## What 0.2.8 fixes

The `threads: 1` config in the current entry was a workaround for two
bugs discovered while adding parallel worker support:

1. `MSGID_DECREASE_RETRY` on the main connection after parallel
   worker RPCs finished. Root cause: `copyAuthFrom` didn't copy
   `_timeOffset`, so same-DC sub-clients created for the worker pool
   encoded msg-id timestamps 1–2 seconds off from main, and later
   main-connection RPCs saw the drift. Fixed by copying `_timeOffset`.

2. Exported workers were running the full updates loop (ping timer +
   `getDifference` polling), which is wasteful and occasionally
   triggered `MSGID_DECREASE_RETRY` on the workers themselves. Fixed
   with a new `workerMode` flag that `exportToDc` sets on sub-clients,
   suppressing the updates loop.

Also raised the internal `_maxWorkers` cap from 3 to 16 so explicit
`threads: N` requests are honored up to 16.

## Local verification

Tested locally at `threads` ∈ {1, 4, 8, 12} on a 4 MiB roundtrip
(download → re-upload → send-as-media). All thread counts complete
byte-exact with no `MSGID_DECREASE_RETRY`, and the main connection is
intact for subsequent RPCs.