### PR TITLE
Update mtflute

### DIFF
--- a/13_mtflute/main.dart
+++ b/13_mtflute/main.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:mtflute/mtflute.dart';
 
-const String _libVersion = '0.2.8';
+const String _libVersion = '0.2.9';
 const int _threads = 4;
 
 Future<void> main(List<String> args) async {

--- a/13_mtflute/pubspec.lock
+++ b/13_mtflute/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: mtflute
-      sha256: b54bac5e2d1bb6b7aa2d6d7447e1a2a45ab564449c491ad1b101a55fb0057b35
+      sha256: b39d6a3a594a816b29b20db5b340aa7ac27951d80d080296255c52467b37d328
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.9"
   pointycastle:
     dependency: transitive
     description:

--- a/13_mtflute/pubspec.yaml
+++ b/13_mtflute/pubspec.yaml
@@ -7,4 +7,4 @@ environment:
   sdk: ^3.8.0
 
 dependencies:
-  mtflute: ^0.2.8
+  mtflute: ^0.2.9


### PR DESCRIPTION
Bumps `13_mtflute` to `mtflute ^0.2.9`.

0.2.9 fixes stability under parallel file transfer, which is exactly the bench workload:

- **Crash fix:** an unhandled async error from `connect()`'s single-flight gate could kill the process mid-download.
- **Outgoing `msgs_ack`:** the client now acknowledges content-related server messages (batched). Missing acks were making the server resend and drop connections under sustained load ("Peer closed connection").
- **Resilient `invoke`:** retries transient network/reconnect errors within a time budget instead of giving up after 3 tries, so a flapping worker recovers.
- **Flap-aware reconnect backoff** + **pipelined download** (workers × pipeline chunks in flight).

Plus a round of MTProto spec-conformance fixes (decrypt padding validation, container inner service messages, gzip unwrap, transport error frames, dh_prime safe-prime check).

Verified locally: multi-thread download (threads 4/8/12) now completes reliably with ~0 connection drops and roughly 2× the throughput of 0.2.8.