### PR TITLE
Update mtgo

### DIFF
--- a/09_mtgo/go.mod
+++ b/09_mtgo/go.mod
@@ -2,7 +2,7 @@ module github.com/rojvv/tglib-bench/09_mtgo
 
 go 1.26.2
 
-require github.com/mtgo-labs/mtgo v0.16.1
+require github.com/mtgo-labs/mtgo v0.16.2
 
 require (
 	github.com/klauspost/compress v1.19.1 // indirect

--- a/09_mtgo/go.sum
+++ b/09_mtgo/go.sum
@@ -1,7 +1,7 @@
 github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
-github.com/mtgo-labs/mtgo v0.16.1 h1:mndFRqbQp7Z5exiYmMIkk6ovArpAMhQTSvRVO9FCfyQ=
-github.com/mtgo-labs/mtgo v0.16.1/go.mod h1:Ic/iVnNWuKAee/FTsA23MCuasar3aEeA2hmdm1BIEzc=
+github.com/mtgo-labs/mtgo v0.16.2 h1:lbvxzYA0RK1d9w7FtBntVb4ptZDGz5tYVQYQ7HRNk9c=
+github.com/mtgo-labs/mtgo v0.16.2/go.mod h1:Ic/iVnNWuKAee/FTsA23MCuasar3aEeA2hmdm1BIEzc=
 github.com/mtgo-labs/session-converter v0.5.0 h1:NO2uPzSaxed7t1+snRLtRopC5jhmlTDwkj0wJcV+lGY=
 github.com/mtgo-labs/session-converter v0.5.0/go.mod h1:C7Ox25A0ZAIngpbZxUs9a1UA/FBGI5Jsq95MjFB4plw=
 github.com/mtgo-labs/storage v0.5.0 h1:x6asAZcLpfhqxEjR6kP4l42246R9XodZGawXsLWLuq8=


### PR DESCRIPTION
## Summary

- update `09_mtgo` from mtgo `v0.16.1` to `v0.16.2`
- include the DC authentication/lifecycle hardening and concurrent-upload reconnect fix
- refresh the Go module checksums for the published release

## Testing

- `go mod verify`
- `go test ./...`
- `go vet ./...`
- `CGO_ENABLED=0 go build ./...`
- local 100 MiB benchmark completed download, upload, and final `SendMedia` successfully
